### PR TITLE
ci: update numpy dependency version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,8 +18,6 @@ updates:
     day: monday
   open-pull-requests-limit: 5
   ignore:
-  # newer versions of numpy break GitLab CI
-  - dependency-name: numpy
   # Sphinx 9 breaks enum-tools; stay on 8.x until fixed upstream
   - dependency-name: sphinx
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,7 @@
 default:
   image: python:3.13
+  tags:
+  - oit-research-apptainer
 
 # Variables (Settings → CI/CD → Variables; Masked=on, Protected=off for MR visibility):
 #   GH_TOKEN         — GitHub PAT: contents, pull_requests, workflows (read/write)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 dependencies = [
   # "neuron", # NEURON cannot be installed from PyPI on Windows
-  "numpy>=2.2,<2.4",  # constrain minor version to avoid CI errors
+  "numpy>=2.2,<3",  # 2.5+ needs Python >=3.12
   "scipy>=1.16,<2",  # 1.18+ needs Python >=3.12
   "nd_line>=0.2,<0.3",
   "aenum>=3.1,<4",

--- a/src/pyfibers/__init__.py
+++ b/src/pyfibers/__init__.py
@@ -11,8 +11,9 @@ import os
 import sys
 from typing import TextIO
 
-import neuron
 import importlib.metadata
+import numpy  # noqa: F401  # import before NEURON; a second C-level init raises RuntimeError
+import neuron
 
 from .compile import running_compile
 


### PR DESCRIPTION
Mirrored from GitLab MR !349 (branch numpy_dep)



---
Source: https://gitlab.oit.duke.edu/wmglab/wmglab-neuron/-/merge_requests/349