### PR TITLE
docs: add Atchuthan EMBC 2025 to pubs using PyFibers

### DIFF
--- a/docs/source/pubs_using.rst
+++ b/docs/source/pubs_using.rst
@@ -9,6 +9,11 @@ Journal articles
 
 - Marshall DP, Upadhye AR, Buyukcelik ON, Shoffstall AJ, Grill WM, Pelot NA (2026) *Computational modeling of human vagus nerve stimulation with three-dimensional fascicular morphology.* APL Bioeng 10(1): 016112. https://doi.org/10.1063/5.0308450
 
+Conference papers
+-----------------
+
+- Atchuthan NA, Grill WM, Meijs S (2025) *Exploring Tonic and Burst Stimulation in Neural Fibers: A Computational Modeling Approach.* Annu Int Conf IEEE Eng Med Biol Soc 2025:1-6. https://doi.org/10.1109/EMBC58623.2025.11253067
+
 Preprints
 ---------
 


### PR DESCRIPTION
Adds Atchuthan, Grill & Meijs (IEEE EMBC 2025) to the publications-using list. This paper uses the PyFibers package (modified MRG via PyFibers). It predates the PLOS paper, so it is package use rather than a citation of that article.

Placed in a new Conference papers section so it is not mixed into journals or preprints.