### PR TITLE
ci: only lint commits not on main in pre-push

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -245,3 +245,4 @@ repos:
     stages: [commit-msg]
   - id: commitizen-branch           # Checks branch commit messages
     stages: [pre-push]
+    args: [--rev-range, origin/main..HEAD]


### PR DESCRIPTION
The `commitizen-branch` pre-push hook was using `$PRE_COMMIT_FROM_REF..$PRE_COMMIT_TO_REF`, so merging `main` into a feature branch and pushing re-checked release commits already on `main`.

Override the rev-range to `origin/main..HEAD` so only commits not already on `main` are checked. GitHub CI already uses `base.sha..head.sha`.

Fixes wmglab/wmglab-neuron#471.