### PR TITLE
docs: add Haberbusch Research Square preprint to pubs using PyFibers

### DIFF
--- a/docs/source/pubs_using.rst
+++ b/docs/source/pubs_using.rst
@@ -24,3 +24,5 @@ Preprints
 - Lung D, Jia Y, Moro A, Fachino M, Haberbusch M (2026) *golgi: open-source software for automated nerve model generation and recruitment simulation.* bioRxiv 2026.07.10.737846. https://doi.org/10.64898/2026.07.10.737846
 
 - Lung D, Haberbusch M (2026) *jaxon: a differentiable, GPU-native simulator for peripheral-nerve fiber models.* bioRxiv 2026.07.30.741846. https://doi.org/10.64898/2026.07.30.741846
+
+- Haberbusch M, Lung D (2026) *A GPU-native, differentiable fiber simulator reveals a species-dependent selectivity penalty in reduced-order peripheral-nerve models.* Research Square. https://doi.org/10.21203/rs.3.rs-10543706/v1


### PR DESCRIPTION
## Summary
- Add Haberbusch & Lung (2026) Research Square preprint to the publications-using list: https://doi.org/10.21203/rs.3.rs-10543706/v1

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have commented my code thoroughly, particularly in hard-to-understand areas
- [ ] I have added a label and reviewer to this pull request
- [x] I have made all relevant changes to the documentation
- [x] I have tested the code and it works as expected (n/a — docs-only)

## Notes for reviewers

Posted 2026-08-25. Distinct from the existing jaxon bioRxiv entry (Lung & Haberbusch); this is the application paper on species-dependent selectivity. It uses PyFibers-wrapped NEURON as the validation reference (99.6% of 943 configurations within 1% threshold error).
